### PR TITLE
Add AssetImage: Docker image built from source

### DIFF
--- a/packages/@aws-cdk/assets/lib/asset.ts
+++ b/packages/@aws-cdk/assets/lib/asset.ts
@@ -124,7 +124,7 @@ export class Asset extends cdk.Construct {
     // for tooling to be able to package and upload a directory to the
     // s3 bucket and plug in the bucket name and key in the correct
     // parameters.
-    const asset: cxapi.AssetMetadataEntry = {
+    const asset: cxapi.FileAssetMetadataEntry = {
       path: this.assetPath,
       id: this.uniqueId,
       packaging: props.packaging,

--- a/packages/@aws-cdk/aws-ecs/lib/asset-image.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/asset-image.ts
@@ -1,0 +1,232 @@
+import cfn = require('@aws-cdk/aws-cloudformation');
+import iam = require('@aws-cdk/aws-iam');
+import lambda = require('@aws-cdk/aws-lambda');
+import cdk = require('@aws-cdk/cdk');
+import cxapi = require('@aws-cdk/cx-api');
+import fs = require('fs');
+import path = require('path');
+import { ContainerDefinition } from './container-definition';
+import { IContainerImage } from './container-image';
+
+export interface AssetImageProps {
+  /**
+   * The directory where the Dockerfile is stored
+   */
+  directory: string;
+}
+
+/**
+ * An image that will be built at deployment time
+ */
+export class AssetImage extends cdk.Construct implements IContainerImage {
+  /**
+   * Full name of this image
+   */
+  public readonly imageName: string;
+
+  /**
+   * Directory where the source files are stored
+   */
+  private readonly directory: string;
+
+  /**
+   * ARN of the repository
+   */
+  private readonly repositoryArn: string;
+
+  constructor(parent: cdk.Construct, id: string, props: AssetImageProps) {
+    super(parent, id);
+
+    // resolve full path
+    this.directory = path.resolve(props.directory);
+    if (!fs.existsSync(this.directory)) {
+      throw new Error(`Cannot find image directory at ${this.directory}`);
+    }
+
+    const repositoryParameter = new cdk.Parameter(this, 'Repository', {
+      type: 'String',
+      description: `Repository ARN for asset "${this.path}"`,
+    });
+
+    const tagParameter = new cdk.Parameter(this, 'Tag', {
+      type: 'String',
+      description: `Tag for asset "${this.path}"`,
+    });
+
+    const asset: cxapi.ContainerImageAssetMetadataEntry = {
+      packaging: 'container-image',
+      path: this.directory,
+      id: this.uniqueId,
+      repositoryParameter: repositoryParameter.logicalId,
+      tagParameter: tagParameter.logicalId
+    };
+
+    this.addMetadata(cxapi.ASSET_METADATA, asset);
+
+    this.repositoryArn = repositoryParameter.value.toString();
+
+    // Require that repository adoption happens first
+    const adopted = new AdoptRegistry(this, 'AdoptRegistry', { repositoryArn: this.repositoryArn });
+    this.imageName = `${adopted.repositoryUri}:${tagParameter.value}`;
+  }
+
+  public bind(containerDefinition: ContainerDefinition): void {
+    // This image will be in ECR, so we need appropriate permissions.
+    containerDefinition.addToExecutionPolicy(new iam.PolicyStatement()
+      .addActions("ecr:BatchCheckLayerAvailability", "ecr:GetDownloadUrlForLayer", "ecr:BatchGetImage")
+      .addResource(this.repositoryArn));
+
+    containerDefinition.addToExecutionPolicy(new iam.PolicyStatement()
+      .addActions("ecr:GetAuthorizationToken", "logs:CreateLogStream", "logs:PutLogEvents")
+      .addAllResources());
+  }
+}
+
+interface AdoptRegistryProps {
+  repositoryArn: string;
+}
+
+/**
+ * Custom Resource which will adopt the registry used for the locally built image into the stack.
+ *
+ * This is so we can clean it up when the stack gets deleted.
+ */
+class AdoptRegistry extends cdk.Construct {
+  public readonly repositoryUri: string;
+
+  constructor(parent: cdk.Construct, id: string, props: AdoptRegistryProps) {
+    super(parent, id);
+
+    const fn = new lambda.SingletonFunction(this, 'Function', {
+      runtime: lambda.Runtime.NodeJS810,
+      lambdaPurpose: 'AdoptEcrRegistry',
+      handler: 'index.handler',
+      code: lambda.Code.inline(`exports.handler = ${trivialMinify(adoptRegistryHandler.toString())}`),
+      uuid: 'dbc60def-c595-44bc-aa5c-28c95d68f62c',
+      timeout: 300
+    });
+
+    fn.addToRolePolicy(new iam.PolicyStatement()
+      .addActions('ecr:GetRepositoryPolicy', 'ecr:SetRepositoryPolicy', 'ecr:DeleteRepository', 'ecr:ListImages', 'ecr:BatchDeleteImage')
+      .addAllResources());
+
+    const resource = new cfn.CustomResource(this, 'Resource', {
+      lambdaProvider: fn,
+      properties: {
+        RepositoryArn: props.repositoryArn,
+      }
+    });
+
+    this.repositoryUri = resource.getAtt('RepositoryUri').toString();
+  }
+}
+
+// tslint:disable:no-console
+async function adoptRegistryHandler(event: any, context: any) {
+  try {
+    const AWS = require('aws-sdk');
+    const ecr = new AWS.ECR();
+
+    console.log(JSON.stringify(event));
+
+    const markerStatement = {
+      Sid: event.StackId,
+      Effect: "Deny",
+      Action: "OwnedBy:CDKStack",
+      Principal: "*"
+    };
+
+    function repoName(props: any) {
+      return props.RepositoryArn.split('/').slice(1).join('/');
+    }
+
+    // The repository must already exist
+    async function getAdopter(name: string): Promise<any> {
+      try {
+        const policyResponse = await ecr.getRepositoryPolicy({ repositoryName: name }).promise();
+        const policy = JSON.parse(policyResponse.policyText);
+        // Search the policy for an adopter marker
+        return (policy.Statement || []).find((x: any) => x.Action === markerStatement.Action) || {};
+      } catch (e) {
+        if (e.code !== 'RepositoryPolicyNotFoundException') { throw e; }
+        return {};
+      }
+    }
+
+    const repo = repoName(event.ResourceProperties);
+    const adopter = await getAdopter(repo);
+    if (event.RequestType === 'Delete') {
+      if (adopter.Sid !== markerStatement.Sid) {
+        throw new Error(`This repository is already owned by another stack: ${adopter.Sid}`);
+      }
+      console.log('Deleting', repo);
+      const ids = (await ecr.listImages({ repositoryName: repo }).promise()).imageIds;
+      try {
+        await ecr.batchDeleteImage({ repositoryName: repo, imageIds: ids }).promise();
+        await ecr.deleteRepository({ repositoryName: repo }).promise();
+      } catch (e) {
+        if (e.code !== 'RepositoryPolicyNotFoundException') { throw e; }
+      }
+    }
+
+    if (event.RequestType === 'Create' || event.RequestType === 'Update') {
+      if (adopter.Sid !== undefined && adopter.Sid !== markerStatement.Sid) {
+        throw new Error(`This repository is already owned by another stack: ${adopter.Sid}`);
+      }
+      console.log('Adopting', repo);
+      await ecr.setRepositoryPolicy({ repositoryName: repo, policyText: JSON.stringify({
+        Version: '2008-10-17',
+        Statement: [markerStatement]
+      }) }).promise();
+    }
+
+    const arn = event.ResourceProperties.RepositoryArn.split(':');
+    await respond("SUCCESS", "OK", repo, {
+      RepositoryUri: `${arn[4]}.dkr.ecr.${arn[3]}.amazonaws.com/${repoName(event.ResourceProperties)}`
+    });
+  } catch (e) {
+    console.log(e);
+    await respond("FAILED", e.message, context.logStreamName, {});
+  }
+
+  function respond(responseStatus: string, reason: string, physId: string, data: any) {
+    const responseBody = JSON.stringify({
+      Status: responseStatus,
+      Reason: reason,
+      PhysicalResourceId: physId,
+      StackId: event.StackId,
+      RequestId: event.RequestId,
+      LogicalResourceId: event.LogicalResourceId,
+      NoEcho: false,
+      Data: data
+    });
+
+    console.log('Responding', JSON.stringify(responseBody));
+
+    const parsedUrl = require('url').parse(event.ResponseURL);
+    const requestOptions = {
+      hostname: parsedUrl.hostname,
+      path: parsedUrl.path,
+      method: "PUT",
+      headers: { "content-type": "", "content-length": responseBody.length }
+    };
+
+    return new Promise<void>((resolve, reject) => {
+      try {
+        const request = require('https').request(requestOptions, resolve);
+        request.on("error", reject);
+        request.write(responseBody);
+        request.end();
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+}
+
+/**
+ * Trivial minification by changing TypeScript's 4-space indentation to 1-space
+ */
+function trivialMinify(s: string) {
+  return s.replace(/^ {4}/mg, ' ');
+}

--- a/packages/@aws-cdk/aws-ecs/lib/container-definition.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/container-definition.ts
@@ -1,6 +1,7 @@
+import iam = require('@aws-cdk/aws-iam');
 import cdk = require('@aws-cdk/cdk');
 import { BaseTaskDefinition, NetworkMode } from './base/base-task-definition';
-import { ContainerImage } from './container-image';
+import { IContainerImage } from './container-image';
 import { cloudformation } from './ecs.generated';
 import { LinuxParameters } from './linux-parameters';
 import { LogDriver } from './log-drivers/log-driver';
@@ -11,9 +12,9 @@ export interface ContainerDefinitionProps {
    *
    * You can use images in the Docker Hub registry or specify other
    * repositories (repository-url/image:tag).
-   * TODO: Update these to specify using classes of ContainerImage
+   * TODO: Update these to specify using classes of IContainerImage
    */
-  image: ContainerImage;
+  image: IContainerImage;
 
   /**
    * The CMD value to pass to the container.
@@ -182,16 +183,18 @@ export class ContainerDefinition extends cdk.Construct {
 
   public readonly essential: boolean;
 
+  public readonly memoryLimitSpecified: boolean;
+
   private readonly links = new Array<string>();
 
   private readonly taskDefinition: BaseTaskDefinition;
-
-  private _usesEcrImages: boolean = false;
 
   constructor(parent: cdk.Construct, id: string, taskDefinition: BaseTaskDefinition, private readonly props: ContainerDefinitionProps) {
     super(parent, id);
     this.essential = props.essential !== undefined ? props.essential : true;
     this.taskDefinition = taskDefinition;
+    this.memoryLimitSpecified = props.memoryLimitMiB !== undefined || props.memoryReservationMiB !== undefined;
+
     props.image.bind(this);
   }
 
@@ -232,14 +235,10 @@ export class ContainerDefinition extends cdk.Construct {
   }
 
   /**
-   * Mark this ContainerDefinition as using an ECR image
+   * Add a statement to the Task Definition's Execution policy
    */
-  public useEcrImage() {
-    this._usesEcrImages = true;
-  }
-
-  public get usesEcrImages() {
-    return this._usesEcrImages;
+  public addToExecutionPolicy(statement: iam.PolicyStatement) {
+    this.taskDefinition.addToExecutionRolePolicy(statement);
   }
 
   /**

--- a/packages/@aws-cdk/aws-ecs/lib/container-image.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/container-image.ts
@@ -1,21 +1,21 @@
 import { ContainerDefinition } from './container-definition';
 
-export abstract class ContainerImage {
-  public abstract readonly imageName: string;
-  public abstract bind(containerDefinition: ContainerDefinition): void;
+export interface IContainerImage {
+  readonly imageName: string;
+  bind(containerDefinition: ContainerDefinition): void;
 }
 
 export class DockerHub {
-  public static image(name: string): ContainerImage {
+  public static image(name: string): IContainerImage {
     return new DockerHubImage(name);
   }
 }
 
-class DockerHubImage {
+class DockerHubImage implements IContainerImage {
   constructor(public readonly imageName: string) {
   }
 
   public bind(_containerDefinition: ContainerDefinition): void {
-    // Nothing
+    // Nothing to do
   }
 }

--- a/packages/@aws-cdk/aws-ecs/lib/ecs/ecs-task-definition.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/ecs/ecs-task-definition.ts
@@ -41,6 +41,18 @@ export class EcsTaskDefinition extends BaseTaskDefinition {
     }
   }
 
+  public validate(): string[] {
+    const ret = super.validate();
+
+    for (const container of this.containers) {
+      if (!container.memoryLimitSpecified) {
+        ret.push(`ECS Container ${container.id} must have at least one of 'memoryLimitMiB' or 'memoryReservationMiB' specified`);
+      }
+    }
+
+    return ret;
+  }
+
   /**
    * Constrain where tasks can be placed
    */

--- a/packages/@aws-cdk/aws-ecs/lib/index.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/index.ts
@@ -13,7 +13,9 @@ export * from './container-definition';
 export * from './container-image';
 export * from './linux-parameters';
 export * from './load-balanced-fargate-service';
+export * from './load-balanced-ecs-service';
 export * from './load-balanced-fargate-service-applet';
+export * from './asset-image';
 
 export * from './log-drivers/log-driver';
 export * from './log-drivers/aws-log-driver';

--- a/packages/@aws-cdk/aws-ecs/lib/load-balanced-ecs-service.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/load-balanced-ecs-service.ts
@@ -1,0 +1,97 @@
+import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2');
+import cdk = require('@aws-cdk/cdk');
+import { IContainerImage } from './container-image';
+import { IEcsCluster } from './ecs/ecs-cluster';
+import { EcsService } from './ecs/ecs-service';
+import { EcsTaskDefinition } from './ecs/ecs-task-definition';
+
+export interface LoadBalancedEcsServiceProps {
+  /**
+   * The cluster where your ECS service will be deployed
+   */
+  cluster: IEcsCluster;
+
+  image: IContainerImage;
+
+  /**
+   * The number of cpu units used by the task.
+   * Valid values, which determines your range of valid values for the memory parameter:
+   * 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+   * 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+   * 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+   * 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+   * 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+   *
+   * This default is set in the underlying EcsTaskDefinition construct.
+   *
+   * @default 256
+   */
+  cpu?: string;
+
+  /**
+   * Hard limit on memory
+   */
+  memoryLimitMiB?: number;
+
+  /**
+   * Memory reservation
+   */
+  memoryReservationMiB?: number;
+
+  /**
+   * The container port of the application load balancer attached to your Ecs service. Corresponds to container port mapping.
+   *
+   * @default 80
+   */
+  containerPort?: number;
+
+  /**
+   * Determines whether the Application Load Balancer will be internet-facing
+   *
+   * @default true
+   */
+  publicLoadBalancer?: boolean;
+}
+
+export class LoadBalancedEcsService extends cdk.Construct {
+  public readonly loadBalancer: elbv2.ApplicationLoadBalancer;
+
+  constructor(parent: cdk.Construct, id: string, props: LoadBalancedEcsServiceProps) {
+    super(parent, id);
+
+    const taskDefinition = new EcsTaskDefinition(this, 'TaskDef', {
+    });
+
+    const container = taskDefinition.addContainer('web', {
+      image: props.image,
+      memoryLimitMiB: props.memoryLimitMiB,
+      memoryReservationMiB: props.memoryReservationMiB,
+    });
+
+    container.addPortMappings({
+      containerPort: props.containerPort || 80,
+    });
+
+    const service = new EcsService(this, "Service", {
+      cluster: props.cluster,
+      taskDefinition,
+    });
+
+    const internetFacing = props.publicLoadBalancer !== undefined ? props.publicLoadBalancer : true;
+    const lb = new elbv2.ApplicationLoadBalancer(this, 'LB', {
+      vpc: props.cluster.vpc,
+      internetFacing
+    });
+
+    this.loadBalancer = lb;
+
+    const listener = lb.addListener('Listener', { port: 80, open: true });
+    listener.addTargets('ECS', {
+      port: 80,
+      targets: [service]
+    });
+
+    // Always output load balancer address, because why not?
+    new cdk.Output(this, 'LoadBalancerDNS', { value: lb.dnsName });
+  }
+}

--- a/packages/@aws-cdk/aws-ecs/lib/load-balanced-fargate-service.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/load-balanced-fargate-service.ts
@@ -1,6 +1,6 @@
 import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2');
 import cdk = require('@aws-cdk/cdk');
-import { ContainerImage } from './container-image';
+import { IContainerImage } from './container-image';
 import { IFargateCluster } from './fargate/fargate-cluster';
 import { FargateService } from './fargate/fargate-service';
 import { FargateTaskDefinition } from './fargate/fargate-task-definition';
@@ -11,7 +11,7 @@ export interface LoadBalancedFargateServiceProps {
    */
   cluster: IFargateCluster;
 
-  image: ContainerImage;
+  image: IContainerImage;
   /**
    * The number of cpu units used by the task.
    * Valid values, which determines your range of valid values for the memory parameter:

--- a/packages/@aws-cdk/aws-ecs/package.json
+++ b/packages/@aws-cdk/aws-ecs/package.json
@@ -54,13 +54,17 @@
   "devDependencies": {
     "@aws-cdk/assert": "^0.12.0",
     "cdk-build-tools": "^0.12.0",
+    "cdk-integ-tools": "^0.12.0",
     "cfn2ts": "^0.12.0",
     "pkglint": "^0.12.0"
   },
   "dependencies": {
     "@aws-cdk/cdk": "^0.12.0",
+    "@aws-cdk/cx-api": "^0.12.0",
     "@aws-cdk/aws-autoscaling": "^0.12.0",
     "@aws-cdk/aws-cloudwatch": "^0.12.0",
+    "@aws-cdk/aws-lambda": "^0.12.0",
+    "@aws-cdk/aws-cloudformation": "^0.12.0",
     "@aws-cdk/aws-ec2": "^0.12.0",
     "@aws-cdk/aws-elasticloadbalancing": "^0.12.0",
     "@aws-cdk/aws-elasticloadbalancingv2": "^0.12.0",

--- a/packages/@aws-cdk/aws-ecs/test/demo-image/Dockerfile
+++ b/packages/@aws-cdk/aws-ecs/test/demo-image/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.6
+EXPOSE 8000
+WORKDIR /src
+ADD . /src
+CMD python3 index.py

--- a/packages/@aws-cdk/aws-ecs/test/demo-image/index.py
+++ b/packages/@aws-cdk/aws-ecs/test/demo-image/index.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+import sys
+import textwrap
+import http.server
+import socketserver
+
+PORT = 8000
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html')
+        self.end_headers()
+        self.wfile.write(textwrap.dedent('''\
+            <!doctype html>
+            <html><head><title>It works</title></head>
+            <body>
+                <h1>Hello from the integ test container</h1>
+                <p>This container got built and started as part of the integ test.</p>
+                <img src="https://media.giphy.com/media/nFjDu1LjEADh6/giphy.gif">
+            </body>
+            ''').encode('utf-8'))
+
+
+def main():
+    httpd = http.server.HTTPServer(("", PORT), Handler)
+    print("serving at port", PORT)
+    httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/packages/@aws-cdk/aws-ecs/test/ecs/integ.asset-image.ts
+++ b/packages/@aws-cdk/aws-ecs/test/ecs/integ.asset-image.ts
@@ -1,0 +1,22 @@
+import ec2 = require('@aws-cdk/aws-ec2');
+import cdk = require('@aws-cdk/cdk');
+import path = require('path');
+import ecs = require('../../lib');
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, 'aws-ecs-integ2');
+const vpc = new ec2.VpcNetwork(stack, 'Vpc', { maxAZs: 2 });
+
+const cluster = new ecs.EcsCluster(stack, 'Cluster', { vpc });
+
+// Instantiate Ecs Service with just cluster and image
+new ecs.LoadBalancedEcsService(stack, "EcsService", {
+  cluster,
+  containerPort: 8000,
+  memoryReservationMiB: 128,
+  image: new ecs.AssetImage(stack, 'Image', {
+    directory: path.join(__dirname, '..', 'demo-image')
+  })
+});
+
+app.run();

--- a/packages/@aws-cdk/aws-ecs/test/fargate/cdk.json
+++ b/packages/@aws-cdk/aws-ecs/test/fargate/cdk.json
@@ -4,6 +4,14 @@
       "eu-west-1a",
       "eu-west-1b",
       "eu-west-1c"
+    ],
+    "availability-zones:993655754359:us-east-1": [
+      "us-east-1a",
+      "us-east-1b",
+      "us-east-1c",
+      "us-east-1d",
+      "us-east-1e",
+      "us-east-1f"
     ]
   }
 }

--- a/packages/@aws-cdk/aws-ecs/test/fargate/integ.asset-image.ts
+++ b/packages/@aws-cdk/aws-ecs/test/fargate/integ.asset-image.ts
@@ -1,0 +1,27 @@
+import ec2 = require('@aws-cdk/aws-ec2');
+import cdk = require('@aws-cdk/cdk');
+import path = require('path');
+import ecs = require('../../lib');
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, 'aws-ecs-integ');
+const vpc = new ec2.VpcNetwork(stack, 'Vpc', { maxAZs: 2 });
+
+const cluster = new ecs.FargateCluster(stack, 'Cluster', { vpc });
+
+Array.isArray(cluster);
+Array.isArray(path);
+
+// Instantiate Fargate Service with just cluster and image
+const fargateService = new ecs.LoadBalancedFargateService(stack, "FargateService", {
+  cluster,
+  containerPort: 8000,
+  image: new ecs.AssetImage(stack, 'Image', {
+    directory: path.join(__dirname, '..', 'demo-image')
+  })
+});
+
+// Output the DNS where you can access your service
+new cdk.Output(stack, 'LoadBalancerDNS', { value: fargateService.loadBalancer.dnsName });
+
+app.run();

--- a/packages/@aws-cdk/aws-ecs/test/integ.asset-image.expected.json
+++ b/packages/@aws-cdk/aws-ecs/test/integ.asset-image.expected.json
@@ -1,0 +1,620 @@
+{
+  "Resources": {
+    "Vpc8378EB38": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/16",
+        "EnableDnsHostnames": true,
+        "EnableDnsSupport": true,
+        "InstanceTenancy": "default",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "aws-ecs-integ/Vpc"
+          }
+        ]
+      }
+    },
+    "VpcPublicSubnet1Subnet5C2D37C4": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/18",
+        "VpcId": {
+          "Ref": "Vpc8378EB38"
+        },
+        "AvailabilityZone": "test-region-1a",
+        "MapPublicIpOnLaunch": true,
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "aws-ecs-integ/Vpc/PublicSubnet1"
+          }
+        ]
+      }
+    },
+    "VpcPublicSubnet1RouteTable6C95E38E": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "Vpc8378EB38"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "aws-ecs-integ/Vpc/PublicSubnet1"
+          }
+        ]
+      }
+    },
+    "VpcPublicSubnet1RouteTableAssociation97140677": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "VpcPublicSubnet1RouteTable6C95E38E"
+        },
+        "SubnetId": {
+          "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+        }
+      }
+    },
+    "VpcPublicSubnet1DefaultRoute3DA9E72A": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "VpcPublicSubnet1RouteTable6C95E38E"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "VpcIGWD7BA715C"
+        }
+      }
+    },
+    "VpcPublicSubnet1EIPD7E02669": {
+      "Type": "AWS::EC2::EIP",
+      "Properties": {
+        "Domain": "vpc"
+      }
+    },
+    "VpcPublicSubnet1NATGateway4D7517AA": {
+      "Type": "AWS::EC2::NatGateway",
+      "Properties": {
+        "AllocationId": {
+          "Fn::GetAtt": [
+            "VpcPublicSubnet1EIPD7E02669",
+            "AllocationId"
+          ]
+        },
+        "SubnetId": {
+          "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "aws-ecs-integ/Vpc/PublicSubnet1"
+          }
+        ]
+      }
+    },
+    "VpcPublicSubnet2Subnet691E08A3": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.0.64.0/18",
+        "VpcId": {
+          "Ref": "Vpc8378EB38"
+        },
+        "AvailabilityZone": "test-region-1b",
+        "MapPublicIpOnLaunch": true,
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "aws-ecs-integ/Vpc/PublicSubnet2"
+          }
+        ]
+      }
+    },
+    "VpcPublicSubnet2RouteTable94F7E489": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "Vpc8378EB38"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "aws-ecs-integ/Vpc/PublicSubnet2"
+          }
+        ]
+      }
+    },
+    "VpcPublicSubnet2RouteTableAssociationDD5762D8": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "VpcPublicSubnet2RouteTable94F7E489"
+        },
+        "SubnetId": {
+          "Ref": "VpcPublicSubnet2Subnet691E08A3"
+        }
+      }
+    },
+    "VpcPublicSubnet2DefaultRoute97F91067": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "VpcPublicSubnet2RouteTable94F7E489"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "VpcIGWD7BA715C"
+        }
+      }
+    },
+    "VpcPublicSubnet2EIP3C605A87": {
+      "Type": "AWS::EC2::EIP",
+      "Properties": {
+        "Domain": "vpc"
+      }
+    },
+    "VpcPublicSubnet2NATGateway9182C01D": {
+      "Type": "AWS::EC2::NatGateway",
+      "Properties": {
+        "AllocationId": {
+          "Fn::GetAtt": [
+            "VpcPublicSubnet2EIP3C605A87",
+            "AllocationId"
+          ]
+        },
+        "SubnetId": {
+          "Ref": "VpcPublicSubnet2Subnet691E08A3"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "aws-ecs-integ/Vpc/PublicSubnet2"
+          }
+        ]
+      }
+    },
+    "VpcPrivateSubnet1Subnet536B997A": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.0.128.0/18",
+        "VpcId": {
+          "Ref": "Vpc8378EB38"
+        },
+        "AvailabilityZone": "test-region-1a",
+        "MapPublicIpOnLaunch": false,
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "aws-ecs-integ/Vpc/PrivateSubnet1"
+          }
+        ]
+      }
+    },
+    "VpcPrivateSubnet1RouteTableB2C5B500": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "Vpc8378EB38"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "aws-ecs-integ/Vpc/PrivateSubnet1"
+          }
+        ]
+      }
+    },
+    "VpcPrivateSubnet1RouteTableAssociation70C59FA6": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "VpcPrivateSubnet1RouteTableB2C5B500"
+        },
+        "SubnetId": {
+          "Ref": "VpcPrivateSubnet1Subnet536B997A"
+        }
+      }
+    },
+    "VpcPrivateSubnet1DefaultRouteBE02A9ED": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "VpcPrivateSubnet1RouteTableB2C5B500"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": {
+          "Ref": "VpcPublicSubnet1NATGateway4D7517AA"
+        }
+      }
+    },
+    "VpcPrivateSubnet2Subnet3788AAA1": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.0.192.0/18",
+        "VpcId": {
+          "Ref": "Vpc8378EB38"
+        },
+        "AvailabilityZone": "test-region-1b",
+        "MapPublicIpOnLaunch": false,
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "aws-ecs-integ/Vpc/PrivateSubnet2"
+          }
+        ]
+      }
+    },
+    "VpcPrivateSubnet2RouteTableA678073B": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "Vpc8378EB38"
+        },
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "aws-ecs-integ/Vpc/PrivateSubnet2"
+          }
+        ]
+      }
+    },
+    "VpcPrivateSubnet2RouteTableAssociationA89CAD56": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "VpcPrivateSubnet2RouteTableA678073B"
+        },
+        "SubnetId": {
+          "Ref": "VpcPrivateSubnet2Subnet3788AAA1"
+        }
+      }
+    },
+    "VpcPrivateSubnet2DefaultRoute060D2087": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "VpcPrivateSubnet2RouteTableA678073B"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": {
+          "Ref": "VpcPublicSubnet2NATGateway9182C01D"
+        }
+      }
+    },
+    "VpcIGWD7BA715C": {
+      "Type": "AWS::EC2::InternetGateway",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "aws-ecs-integ/Vpc"
+          }
+        ]
+      }
+    },
+    "VpcVPCGWBF912B6E": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "VpcId": {
+          "Ref": "Vpc8378EB38"
+        },
+        "InternetGatewayId": {
+          "Ref": "VpcIGWD7BA715C"
+        }
+      }
+    },
+    "ClusterEB0386A7": {
+      "Type": "AWS::ECS::Cluster"
+    },
+    "FargateServiceTaskDefTaskRole8CDCF85E": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRole",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "FargateServiceTaskDef940E3A80": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Essential": true,
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "ImageRepositoryC2BE7AD4"
+                  },
+                  ":",
+                  {
+                    "Ref": "ImageTagE17D8A6B"
+                  }
+                ]
+              ]
+            },
+            "Links": [],
+            "LinuxParameters": {
+              "Capabilities": {
+                "Add": [],
+                "Drop": []
+              },
+              "Devices": [],
+              "Tmpfs": []
+            },
+            "MountPoints": [],
+            "Name": "web",
+            "PortMappings": [
+              {
+                "ContainerPort": 8000,
+                "Protocol": "tcp"
+              }
+            ],
+            "Ulimits": [],
+            "VolumesFrom": []
+          }
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "FargateServiceTaskDefExecutionRole9194820E",
+            "Arn"
+          ]
+        },
+        "Family": "awsecsintegFargateServiceTaskDefE1C73F14",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "FargateServiceTaskDefTaskRole8CDCF85E",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "FargateServiceTaskDefExecutionRole9194820E": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRole",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com"
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+              ]
+            ]
+          }
+        ]
+      }
+    },
+    "FargateServiceECC8084D": {
+      "Type": "AWS::ECS::Service",
+      "Properties": {
+        "TaskDefinition": {
+          "Ref": "FargateServiceTaskDef940E3A80"
+        },
+        "Cluster": {
+          "Ref": "ClusterEB0386A7"
+        },
+        "DeploymentConfiguration": {},
+        "DesiredCount": 1,
+        "LaunchType": "FARGATE",
+        "LoadBalancers": [
+          {
+            "ContainerName": "web",
+            "ContainerPort": 8000,
+            "TargetGroupArn": {
+              "Ref": "FargateServiceLBPublicListenerECSGroupBE57E081"
+            }
+          }
+        ],
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "AssignPublicIp": "DISABLED",
+            "SecurityGroups": [
+              {
+                "Fn::GetAtt": [
+                  "FargateServiceSecurityGroup262B61DD",
+                  "GroupId"
+                ]
+              }
+            ],
+            "Subnets": [
+              {
+                "Ref": "VpcPrivateSubnet1Subnet536B997A"
+              },
+              {
+                "Ref": "VpcPrivateSubnet2Subnet3788AAA1"
+              }
+            ]
+          }
+        }
+      },
+      "DependsOn": [
+        "FargateServiceLBPublicListener4B4929CA"
+      ]
+    },
+    "FargateServiceSecurityGroup262B61DD": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "aws-ecs-integ/FargateService/Service/SecurityGroup",
+        "SecurityGroupEgress": [],
+        "SecurityGroupIngress": [],
+        "VpcId": {
+          "Ref": "Vpc8378EB38"
+        }
+      }
+    },
+    "FargateServiceSecurityGroupfromawsecsintegFargateServiceLBSecurityGroup129467A18000AD32AE25": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "IpProtocol": "tcp",
+        "Description": "Load balancer to target",
+        "FromPort": 8000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "FargateServiceSecurityGroup262B61DD",
+            "GroupId"
+          ]
+        },
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "FargateServiceLBSecurityGroup5F444C78",
+            "GroupId"
+          ]
+        },
+        "ToPort": 8000
+      }
+    },
+    "FargateServiceLBB353E155": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "LoadBalancerAttributes": [],
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "FargateServiceLBSecurityGroup5F444C78",
+              "GroupId"
+            ]
+          }
+        ],
+        "Subnets": [
+          {
+            "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+          },
+          {
+            "Ref": "VpcPublicSubnet2Subnet691E08A3"
+          }
+        ],
+        "Type": "application"
+      }
+    },
+    "FargateServiceLBSecurityGroup5F444C78": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Automatically created Security Group for ELB awsecsintegFargateServiceLB5FE4725D",
+        "SecurityGroupEgress": [],
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 80",
+            "FromPort": 80,
+            "IpProtocol": "tcp",
+            "ToPort": 80
+          }
+        ],
+        "VpcId": {
+          "Ref": "Vpc8378EB38"
+        }
+      }
+    },
+    "FargateServiceLBSecurityGrouptoawsecsintegFargateServiceSecurityGroup8930AEB880001FF8BADE": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties": {
+        "GroupId": {
+          "Fn::GetAtt": [
+            "FargateServiceLBSecurityGroup5F444C78",
+            "GroupId"
+          ]
+        },
+        "IpProtocol": "tcp",
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "FargateServiceSecurityGroup262B61DD",
+            "GroupId"
+          ]
+        },
+        "FromPort": 8000,
+        "ToPort": 8000
+      }
+    },
+    "FargateServiceLBPublicListener4B4929CA": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "FargateServiceLBPublicListenerECSGroupBE57E081"
+            },
+            "Type": "forward"
+          }
+        ],
+        "LoadBalancerArn": {
+          "Ref": "FargateServiceLBB353E155"
+        },
+        "Port": 80,
+        "Protocol": "HTTP",
+        "Certificates": []
+      }
+    },
+    "FargateServiceLBPublicListenerECSGroupBE57E081": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "Port": 80,
+        "Protocol": "HTTP",
+        "VpcId": {
+          "Ref": "Vpc8378EB38"
+        },
+        "TargetGroupAttributes": [],
+        "Targets": [],
+        "TargetType": "ip"
+      }
+    }
+  },
+  "Parameters": {
+    "ImageRepositoryC2BE7AD4": {
+      "Type": "String",
+      "Description": "Repository for asset \"aws-ecs-integ/Image\""
+    },
+    "ImageTagE17D8A6B": {
+      "Type": "String",
+      "Description": "Tag for asset \"aws-ecs-integ/Image\""
+    }
+  },
+  "Outputs": {
+    "LoadBalancerDNS": {
+      "Value": {
+        "Fn::GetAtt": [
+          "FargateServiceLBB353E155",
+          "DNSName"
+        ]
+      },
+      "Export": {
+        "Name": "aws-ecs-integ:LoadBalancerDNS"
+      }
+    }
+  }
+}

--- a/packages/@aws-cdk/cx-api/lib/cxapi.ts
+++ b/packages/@aws-cdk/cx-api/lib/cxapi.ts
@@ -79,7 +79,13 @@ export const DEFAULT_ACCOUNT_CONTEXT_KEY = 'aws:cdk:toolkit:default-account';
 export const DEFAULT_REGION_CONTEXT_KEY = 'aws:cdk:toolkit:default-region';
 
 export const ASSET_METADATA = 'aws:cdk:asset';
-export interface AssetMetadataEntry {
+
+export interface FileAssetMetadataEntry {
+  /**
+   * Requested packaging style
+   */
+  packaging: 'zip' | 'file';
+
   /**
    * Path on disk to the asset
    */
@@ -91,11 +97,6 @@ export interface AssetMetadataEntry {
   id: string;
 
   /**
-   * Requested packaging style
-   */
-  packaging: 'zip' | 'file';
-
-  /**
    * Name of parameter where S3 bucket should be passed in
    */
   s3BucketParameter: string;
@@ -105,6 +106,35 @@ export interface AssetMetadataEntry {
    */
   s3KeyParameter: string;
 }
+
+export interface ContainerImageAssetMetadataEntry {
+  /**
+   * Type of asset
+   */
+  packaging: 'container-image';
+
+  /**
+   * Path on disk to the asset
+   */
+  path: string;
+
+  /**
+   * Logical identifier for the asset
+   */
+  id: string;
+
+  /**
+   * Name of the parameter that takes the repository name
+   */
+  repositoryParameter: string;
+
+  /**
+   * Name of the parameter that takes the tag
+   */
+  tagParameter: string;
+}
+
+export type AssetMetadataEntry = FileAssetMetadataEntry | ContainerImageAssetMetadataEntry;
 
 /**
  * Metadata key used to print INFO-level messages by the toolkit when an app is syntheized.

--- a/packages/aws-cdk/lib/api/util/sdk.ts
+++ b/packages/aws-cdk/lib/api/util/sdk.ts
@@ -104,6 +104,13 @@ export class SDK {
     });
   }
 
+  public async ecr(environment: Environment, mode: Mode): Promise<AWS.ECR> {
+    return new AWS.ECR({
+      region: environment.region,
+      credentials: await this.credentialsCache.get(environment.account, mode)
+    });
+  }
+
   public async defaultRegion(): Promise<string | undefined> {
     return await getCLICompatibleDefaultRegion(this.profile);
   }

--- a/packages/aws-cdk/lib/assets.ts
+++ b/packages/aws-cdk/lib/assets.ts
@@ -1,10 +1,12 @@
-import { ASSET_METADATA, ASSET_PREFIX_SEPARATOR, AssetMetadataEntry, StackMetadata, SynthesizedStack } from '@aws-cdk/cx-api';
+// tslint:disable-next-line:max-line-length
+import { ASSET_METADATA, ASSET_PREFIX_SEPARATOR, AssetMetadataEntry, FileAssetMetadataEntry, StackMetadata, SynthesizedStack } from '@aws-cdk/cx-api';
 import { CloudFormation } from 'aws-sdk';
 import fs = require('fs-extra');
 import os = require('os');
 import path = require('path');
 import { ToolkitInfo } from './api/toolkit-info';
 import { zipDirectory } from './archive';
+import { prepareContainerAsset } from './docker';
 import { debug, success } from './logging';
 
 export async function prepareAssets(stack: SynthesizedStack, toolkitInfo?: ToolkitInfo): Promise<CloudFormation.Parameter[]> {
@@ -35,12 +37,15 @@ async function prepareAsset(asset: AssetMetadataEntry, toolkitInfo: ToolkitInfo)
       return await prepareZipAsset(asset, toolkitInfo);
     case 'file':
       return await prepareFileAsset(asset, toolkitInfo);
+    case 'container-image':
+      return await prepareContainerAsset(asset, toolkitInfo);
     default:
-      throw new Error(`Unsupported packaging type: ${asset.packaging}`);
+      // tslint:disable-next-line:max-line-length
+      throw new Error(`Unsupported packaging type: ${(asset as any).packaging}. You might need to upgrade your aws-cdk toolkit to support this asset type.`);
   }
 }
 
-async function prepareZipAsset(asset: AssetMetadataEntry, toolkitInfo: ToolkitInfo): Promise<CloudFormation.Parameter[]> {
+async function prepareZipAsset(asset: FileAssetMetadataEntry, toolkitInfo: ToolkitInfo): Promise<CloudFormation.Parameter[]> {
   debug('Preparing zip asset from directory:', asset.path);
   const staging = await fs.mkdtemp(path.join(os.tmpdir(), 'cdk-assets'));
   try {
@@ -60,7 +65,7 @@ async function prepareZipAsset(asset: AssetMetadataEntry, toolkitInfo: ToolkitIn
  * @param contentType Content-type to use when uploading to S3 (none will be specified by default)
  */
 async function prepareFileAsset(
-    asset: AssetMetadataEntry,
+    asset: FileAssetMetadataEntry,
     toolkitInfo: ToolkitInfo,
     filePath?: string,
     contentType?: string): Promise<CloudFormation.Parameter[]> {

--- a/packages/aws-cdk/lib/docker.ts
+++ b/packages/aws-cdk/lib/docker.ts
@@ -1,0 +1,208 @@
+import { ContainerImageAssetMetadataEntry } from '@aws-cdk/cx-api';
+import { CloudFormation } from 'aws-sdk';
+import crypto = require('crypto');
+import { ToolkitInfo } from './api/toolkit-info';
+import { debug, print } from './logging';
+import { shell } from './os';
+import { PleaseHold } from './util/please-hold';
+
+/**
+ * Build and upload a Docker image
+ *
+ * Permanently identifying images is a bit of a bust. Newer Docker version use
+ * a digest (sha256:xxxx) as an image identifier, which is pretty good to avoid
+ * spurious rebuilds. However, this digest is calculated over a manifest that
+ * includes metadata that is liable to change. For example, as soon as we
+ * push the Docker image to a repository, the digest changes. This makes the
+ * digest worthless to determe whether we already pushed an image, for example.
+ *
+ * As a workaround, we calculate our own digest over parts of the manifest that
+ * are unlikely to change, and tag based on that.
+ */
+export async function prepareContainerAsset(asset: ContainerImageAssetMetadataEntry, toolkitInfo: ToolkitInfo): Promise<CloudFormation.Parameter[]> {
+  debug(' 👑  Preparing Docker image asset:', asset.path);
+
+  const buildHold = new PleaseHold(` ⌛ Building Docker image for ${asset.path}; this may take a while.`);
+  try {
+    buildHold.start();
+
+    const command = ['docker',
+      'build',
+      '--quiet',
+      asset.path];
+    const imageId = (await shell(command, { quiet: true })).trim();
+    buildHold.stop();
+
+    const tag = await calculateImageDigest(imageId);
+
+    debug(` ⌛  Image has tag ${tag}, preparing ECR repository`);
+    const ecr = await toolkitInfo.prepareEcrRepository(asset.id, tag);
+
+    if (ecr.alreadyExists) {
+      debug(' 👑  Image already uploaded.');
+    } else {
+      // Login and push
+      debug(` ⌛  Image needs to be uploaded first.`);
+
+      await shell(['docker', 'login',
+        '--username', ecr.username,
+        '--password', ecr.password,
+        ecr.endpoint]);
+
+      const qualifiedImageName = `${ecr.repositoryUri}:${tag}`;
+      await shell(['docker', 'tag', imageId, qualifiedImageName]);
+
+      // There's no way to make this quiet, so we can't use a PleaseHold. Print a header message.
+      print(` ⌛ Pusing Docker image for ${asset.path}; this may take a while.`);
+      await shell(['docker', 'push', qualifiedImageName]);
+    }
+
+    return [
+      { ParameterKey: asset.repositoryParameter, ParameterValue: ecr.repositoryArn },
+      { ParameterKey: asset.tagParameter, ParameterValue: tag },
+    ];
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      // tslint:disable-next-line:max-line-length
+      throw new Error('Error building Docker image asset; you need to have Docker installed in order to be able to build image assets. Please install Docker and try again.');
+    }
+    throw e;
+  } finally {
+    buildHold.stop();
+  }
+}
+
+/**
+ * Calculate image digest
+ */
+async function calculateImageDigest(imageId: string) {
+  const manifest = await shell(['docker', 'inspect', imageId], { quiet: true });
+  const parsed = JSON.parse(manifest)[0];
+
+  const importantParts = {
+    Parent: parsed.Parent,
+    Comment: parsed.Comment,
+    Config: parsed.Config,
+    RootFS: parsed.RootFS,
+    Architecture: parsed.Architecture,
+    Os: parsed.Os,
+    Size: parsed.Size,
+    VirtualSize: parsed.VirtualSize,
+    GraphDriver: parsed.GraphDriver
+  };
+
+  return crypto.createHash('sha256').update(JSON.stringify(importantParts)).digest('hex');
+}
+
+/**
+ * Example of a Docker manifest
+ *
+ * [
+ *     {
+ *         "Id": "sha256:3a90542991d03007fd1d8f3b3a6ab04ebb02386785430fe48a867768a048d828",
+ *         "RepoTags": [
+ *             "993655754359.dkr.ecr.us-east-1.amazonaws.com/cdk/awsecsintegimage7c15b8c6:latest"
+ *         ],
+ *         "RepoDigests": [
+ *             "993655754359.dkr.ecr.us-east-1.amazo....5e50c0cfc3f2355191934b05df68cd3339a044959111ffec2e14765"
+ *         ],
+ *         "Parent": "sha256:465720f8f43c9c0aff5dcc731d4e368a3927cae4e885442d4ba0bf8a867b7561",
+ *         "Comment": "",
+ *         "Created": "2018-10-17T10:16:40.775888476Z",
+ *         "Container": "20f145d2e7fbf126ca9f4422497b932bc96b5faa038dc032de1e246f64e03a66",
+ *         "ContainerConfig": {
+ *             "Hostname": "9b48b580a312",
+ *             "Domainname": "",
+ *             "User": "",
+ *             "AttachStdin": false,
+ *             "AttachStdout": false,
+ *             "AttachStderr": false,
+ *             "ExposedPorts": {
+ *                 "8000/tcp": {}
+ *             },
+ *             "Tty": false,
+ *             "OpenStdin": false,
+ *             "StdinOnce": false,
+ *             "Env": [
+ *                 "PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+ *                 "LANG=C.UTF-8",
+ *                 "GPG_KEY=0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D",
+ *                 "PYTHON_VERSION=3.6.6",
+ *                 "PYTHON_PIP_VERSION=18.1"
+ *             ],
+ *             "Cmd": [
+ *                 "/bin/sh",
+ *                 "-c",
+ *                 "#(nop) ",
+ *                 "CMD [\"/bin/sh\" \"-c\" \"python3 index.py\"]"
+ *             ],
+ *             "ArgsEscaped": true,
+ *             "Image": "sha256:465720f8f43c9c0aff5dcc731d4e368a3927cae4e885442d4ba0bf8a867b7561",
+ *             "Volumes": null,
+ *             "WorkingDir": "/code",
+ *             "Entrypoint": null,
+ *             "OnBuild": [],
+ *             "Labels": {}
+ *         },
+ *         "DockerVersion": "17.03.2-ce",
+ *         "Author": "",
+ *         "Config": {
+ *             "Hostname": "9b48b580a312",
+ *             "Domainname": "",
+ *             "User": "",
+ *             "AttachStdin": false,
+ *             "AttachStdout": false,
+ *             "AttachStderr": false,
+ *             "ExposedPorts": {
+ *                 "8000/tcp": {}
+ *             },
+ *             "Tty": false,
+ *             "OpenStdin": false,
+ *             "StdinOnce": false,
+ *             "Env": [
+ *                 "PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+ *                 "LANG=C.UTF-8",
+ *                 "GPG_KEY=0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D",
+ *                 "PYTHON_VERSION=3.6.6",
+ *                 "PYTHON_PIP_VERSION=18.1"
+ *             ],
+ *             "Cmd": [
+ *                 "/bin/sh",
+ *                 "-c",
+ *                 "python3 index.py"
+ *             ],
+ *             "ArgsEscaped": true,
+ *             "Image": "sha256:465720f8f43c9c0aff5dcc731d4e368a3927cae4e885442d4ba0bf8a867b7561",
+ *             "Volumes": null,
+ *             "WorkingDir": "/code",
+ *             "Entrypoint": null,
+ *             "OnBuild": [],
+ *             "Labels": {}
+ *         },
+ *         "Architecture": "amd64",
+ *         "Os": "linux",
+ *         "Size": 917730468,
+ *         "VirtualSize": 917730468,
+ *         "GraphDriver": {
+ *             "Name": "aufs",
+ *             "Data": null
+ *         },
+ *         "RootFS": {
+ *             "Type": "layers",
+ *             "Layers": [
+ *                 "sha256:f715ed19c28b66943ac8bc12dbfb828e8394de2530bbaf1ecce906e748e4fdff",
+ *                 "sha256:8bb25f9cdc41e7d085033af15a522973b44086d6eedd24c11cc61c9232324f77",
+ *                 "sha256:08a01612ffca33483a1847c909836610610ce523fb7e1aca880140ee84df23e9",
+ *                 "sha256:1191b3f5862aa9231858809b7ac8b91c0b727ce85c9b3279932f0baacc92967d",
+ *                 "sha256:9978d084fd771e0b3d1acd7f3525d1b25288ababe9ad8ed259b36101e4e3addd",
+ *                 "sha256:2f4f74d3821ecbdd60b5d932452ea9e30cecf902334165c4a19837f6ee636377",
+ *                 "sha256:003bb6178bc3218242d73e51d5e9ab2f991dc607780194719c6bd4c8c412fe8c",
+ *                 "sha256:15b32d849da2239b1af583f9381c7a75d7aceba12f5ddfffa7a059116cf05ab9",
+ *                 "sha256:6e5c5f6bf043bc634378b1e4b61af09be74741f2ac80204d7a373713b1fd5a40",
+ *                 "sha256:3260e00e353bfb765b25597d13868c2ef64cb3d509875abcfb58c4e9bf7f4ee2",
+ *                 "sha256:f3274b75856311e92e14a1270c78737c86456d6353fe4a83bd2e81bcd2a996ea"
+ *             ]
+ *         }
+ *     }
+ * ]
+ */

--- a/packages/aws-cdk/lib/logging.ts
+++ b/packages/aws-cdk/lib/logging.ts
@@ -3,7 +3,7 @@ import util = require('util');
 
 // tslint:disable:no-console the whole point of those methods is precisely to output to the console...
 
-let isVerbose = false;
+export let isVerbose = false;
 
 export function setVerbose(enabled = true) {
   isVerbose = enabled;

--- a/packages/aws-cdk/lib/os.ts
+++ b/packages/aws-cdk/lib/os.ts
@@ -1,0 +1,98 @@
+import child_process = require("child_process");
+import colors = require('colors/safe');
+import { debug } from "./logging";
+
+export interface ShellOptions extends child_process.SpawnOptions {
+  quiet?: boolean;
+}
+
+/**
+ * OS helpers
+ *
+ * Shell function which both prints to stdout and collects the output into a
+ * string.
+ */
+export async function shell(command: string[], options: ShellOptions = {}): Promise<string> {
+  debug(`Executing ${colors.blue(renderCommandLine(command))}`);
+  const child = child_process.spawn(command[0], command.slice(1), {
+    ...options,
+    stdio: [ 'ignore', 'pipe', 'inherit' ]
+  });
+
+  return new Promise<string>((resolve, reject) => {
+    const stdout = new Array<any>();
+
+    // Both write to stdout and collect
+    child.stdout.on('data', chunk => {
+      if (!options.quiet) {
+        process.stdout.write(chunk);
+      }
+      stdout.push(chunk);
+    });
+
+    child.once('error', reject);
+
+    child.once('exit', code => {
+      if (code === 0) {
+        resolve(Buffer.concat(stdout).toString('utf-8'));
+      } else {
+        reject(new Error(`${renderCommandLine(command)} exited with error code ${code}`));
+      }
+    });
+  });
+}
+
+/**
+ * Render the given command line as a string
+ *
+ * Probably missing some cases but giving it a good effort.
+ */
+function renderCommandLine(cmd: string[]) {
+  if (process.platform !== 'win32') {
+    return doRender(cmd, hasAnyChars(' ', '\\', '!', '"', "'", '&', '$'), posixEscape);
+  } else {
+    return doRender(cmd, hasAnyChars(' ', '"', '&', '^', '%'), windowsEscape);
+  }
+}
+
+/**
+ * Render a UNIX command line
+ */
+function doRender(cmd: string[], needsEscaping: (x: string) => boolean, doEscape: (x: string) => string): string {
+  return cmd.map(x => needsEscaping(x) ? doEscape(x) : x).join(' ');
+}
+
+/**
+ * Return a predicate that checks if a string has any of the indicated chars in it
+ */
+function hasAnyChars(...chars: string[]): (x: string) => boolean {
+  return (str: string) => {
+    return chars.some(c => str.indexOf(c) !== -1);
+  };
+}
+
+/**
+ * Escape a shell argument for POSIX shells
+ *
+ * Wrapping in single quotes and escaping single quotes inside will do it for us.
+ */
+function posixEscape(x: string) {
+  // Turn ' -> '"'"'
+  x = x.replace("'", "'\"'\"'");
+  return `'${x}'`;
+}
+
+/**
+ * Escape a shell argument for cmd.exe
+ *
+ * This is how to do it right, but I'm not following everything:
+ *
+ * https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+ */
+function windowsEscape(x: string): string {
+  // First surround by double quotes, ignore the part about backslashes
+  x = `"${x}"`;
+  // Now escape all special characters
+  const shellMeta = ['"', '&', '^', '%'];
+  return x.split('').map(c => shellMeta.indexOf(x) !== -1 ? '^' + c : c).join('');
+}

--- a/packages/aws-cdk/lib/util/please-hold.ts
+++ b/packages/aws-cdk/lib/util/please-hold.ts
@@ -1,0 +1,25 @@
+import { warning } from "../logging";
+
+/**
+ * Print a message to the logger in case the operation takes a long time
+ */
+export class PleaseHold {
+  private handle?: NodeJS.Timer;
+
+  constructor(private readonly message: string, private readonly timeoutSec = 10) {
+  }
+
+  public start() {
+    this.handle = setTimeout(this.printMessage.bind(this), this.timeoutSec * 1000);
+  }
+
+  public stop() {
+    if (this.handle) {
+      clearTimeout(this.handle);
+    }
+  }
+
+  private printMessage() {
+    warning(this.message);
+  }
+}


### PR DESCRIPTION
Also in this commit:

- ContainerImage changed to an interface, because AssetImage needs to
  be a construct but DockerHubImage doesn't.
- ECR containers now don't add the general managed ECS policy, but
  add fine-grained read permissions to the correct repository (requested
  by AWS security).
- Add validation to ECS TaskDefinitions (to make it impossible to forget
  specifying memory limits in ContainerDefs).
- Add LoadBalancedEcsService.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
